### PR TITLE
Param won't release internal buffer when Type==void*.

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -138,6 +138,8 @@ namespace core
 
         virtual ~TypedParam()
         {
+            if(m_typeId == TypeId<void*, ARGUMENTS>::value) //When Type==void* Param holds no ownership on the data.
+                return;
             Type* typedBuffer = reinterpret_cast<Type*>(m_rawBuffer);
             typedBuffer->~Type();
             delete[] m_rawBuffer;


### PR DESCRIPTION
Param won't release its internal buffer when Type==void*, its present no ownership on the pointed memory.